### PR TITLE
Changes in how types are checked

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -184,7 +184,7 @@ class ParametricType extends Type {
   }
 
   concretize(mappingsBetweenTypeVariableToConcreteType) {
-    return mappingsBetweenTypeVariableToConcreteType[this.typeVariableName] || this;
+    return mappingsBetweenTypeVariableToConcreteType[this.typeVariableName] || new ParametricType(this.typeVariableName + "'");
   }
 
   parametricMappings(aConcreteType) {

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -370,6 +370,23 @@ describe('Connections', () => {
         assertRejectedConnection(outerComposition, innerInputComposition)
       })
 
+      onWorkspace('should connect functions that use parametric types that collide with the composition parametric types correctly', workspace => {
+        const composition = workspace.newBlock('composition')
+        const id = workspace.newBlock('id')
+        const even = workspace.newBlock('even')
+        const zero = workspace.newBlock('math_number')
+
+        // id . even $ 0
+
+        connect(composition, id, 0)
+        connect(composition, even, 1)
+        connect(composition, zero, 2)
+
+        assertConnection(composition, id)
+        assertConnection(composition, even)
+        assertConnection(composition, zero)
+      })
+
       onWorkspace('should connect expected value', workspace => {
         const composition = workspace.newBlock('composition')
         const charAt = workspace.newBlock('charAt')

--- a/test/connectionSpec.js
+++ b/test/connectionSpec.js
@@ -370,7 +370,7 @@ describe('Connections', () => {
         assertRejectedConnection(outerComposition, innerInputComposition)
       })
 
-      onWorkspace('should connect functions that use parametric types that collide with the composition parametric types correctly', workspace => {
+      onWorkspace('should connect functions that use parametric types that collide with the composition parametric types when they are composable', workspace => {
         const composition = workspace.newBlock('composition')
         const id = workspace.newBlock('id')
         const even = workspace.newBlock('even')
@@ -385,6 +385,21 @@ describe('Connections', () => {
         assertConnection(composition, id)
         assertConnection(composition, even)
         assertConnection(composition, zero)
+      })
+
+      onWorkspace('should not connect functions that use parametric types that collide with the composition parametric types when they are not composable', workspace => {
+        const composition = workspace.newBlock('composition')
+        const id = workspace.newBlock('id')
+        const not = workspace.newBlock('not')
+        const zero = workspace.newBlock('math_number')
+
+        // not . id $ 0
+
+        connect(composition, not, 0)
+        connect(composition, id, 1)
+        connect(composition, zero, 2)
+
+        assertRejectedConnection(composition, zero)
       })
 
       onWorkspace('should connect expected value', workspace => {

--- a/test/typeSpec.js
+++ b/test/typeSpec.js
@@ -12,7 +12,7 @@ describe('Types', () => {
 
     onWorkspace('type', workspace => {
       const even = workspace.newBlock('even')
-      assertType(even, 'Number', 'Boolean')
+      assertType(even, ['Number', 'Boolean'])
     })
 
     onWorkspace('applied type', workspace => {
@@ -28,21 +28,21 @@ describe('Types', () => {
 
     onWorkspace('type', workspace => {
       const charAt = workspace.newBlock('charAt')
-      assertType(charAt, 'Number', 'String', 'String')
+      assertType(charAt, ['Number', 'String', 'String'])
     })
 
     onWorkspace('first param applied type', workspace => {
       const charAt = workspace.newBlock('charAt')
       const number = workspace.newBlock('math_number')
       connect(charAt, number, 0)
-      assertType(charAt, 'String', 'String')
+      assertType(charAt, ['String', 'String'])
     })
 
     onWorkspace('second param applied type', workspace => {
       const charAt = workspace.newBlock('charAt')
       const text = workspace.newBlock('text')
       connect(charAt, text, 1)
-      assertType(charAt, 'Number', 'String')
+      assertType(charAt, ['Number', 'String'])
     })
 
   })
@@ -51,26 +51,26 @@ describe('Types', () => {
 
     onWorkspace('input parametric type', workspace => {
       const compare = workspace.newBlock('compare')
-      assertType(compare, 'a', 'a', 'Boolean')
+      assertType(compare, ['a', 'a', 'Boolean'])
     })
 
     onWorkspace('output parametric type', workspace => {
       const id = workspace.newBlock('id')
-      assertType(id, 'a', 'a')
+      assertType(id, ['a', 'a'])
     })
 
     onWorkspace('inferred input type', workspace => {
       const compare = workspace.newBlock('compare')
       const number = workspace.newBlock('math_number')
       connect(compare, number, 0)
-      assertType(compare, 'Number', 'Boolean')
+      assertType(compare, ['Number', 'Boolean'])
     })
 
     onWorkspace('inferred output type', workspace => {
       const id = workspace.newBlock('id')
       const number = workspace.newBlock('math_number')
       connect(id, number, 0)
-      assertType(id, 'Number')
+      assertType(id, ['Number'])
     })
   })
 
@@ -78,13 +78,13 @@ describe('Types', () => {
 
     onWorkspace('type', workspace => {
       const composition = workspace.newBlock('composition')
-      assertType(composition, 'Any', 'Any', 'Any', 'Any')
+      assertType(composition, [['b','c'], ['a', 'b'], 'a', 'c'])
     })
 
   })
 
 })
 
-const assertType = (block, ...types) => {
-  assert.equal(functionType(block), asFunctionType(...types))
+const assertType = (block, type) => {
+  assert.equal(currentType(block).toString(), createType(type).toString())
 }


### PR DESCRIPTION
## Changes

Modeled the types by categorizing them into 3 kinds of types: Function types, Single types and Parametric types. Also, created a superclass for them with just abstract methods to make it easier for me to remember which ones should I definitely implement in new classes :P (originally I only had function and single types).

Function types can contain other types as its input and output.

By this model, all types are currified by default.
Most work is handled by the types themselves, with the applied method you can get the result of applying a single, parametric type or another function type to a function type (including replacing any parametric type in the original function type by concretes types provided)
This makes compositions and high order functions not be an special case.

The position is needed in several methods related with function types to allow applying parameters even when they are not the first one (since the model is currified by default this got a bit tricker and that parameter was needed).

Another change made was on how the checks are done on the blocks:
- Now there aren't different checks for functions, compositions and values. We only check the onChange for functions (compositions are functions so use this as well), and instead of checking the parent connections, we check the children connections (this covers the case of applying a value to a function).

The behaviour was changed a bit, now, if we are applying several parameters to a function, and we pass a parameter that doesn't type check, the one that will be bumped is the one we just tried to apply. The parameters that were already in the function are kept there. This was kind of accidental because I didn't know how to bump all of the parameters :P.

## Tests

Modified tests a bit to conform with the new behaviour of dropping the newest __wrong__ parameters. Also, changed the way we tested the types.
Apart from that, added tests for nested compositions.

![composicionLoca](https://user-images.githubusercontent.com/11432672/80451485-5fe0f000-88fa-11ea-9e59-06c0a9d266d6.gif)

## Next steps

I think that we don't need the types validations Blockly makes anymore, so I suggest that going forward we remove that from our custom blocks so we can catch all the errors ourselves and handle the way we want (like showing a type error somewhere).

## Detected problem

The way we are replacing parametric types by other parametric types from values passed as parameters isn't really good. There was an attempt to fix some of these problems by modifying the already existing parametric types by adding a ' to their name when new parametric types are added, but this could easily fail if there were parametric types with ' in their names already.
I guess we could work around this by not using ' as an identifier for the parametric types _we_ define, but it'd be cool to find a better way to do these replacements.