### PR TITLE
Reduce blocks

### DIFF
--- a/index.md
+++ b/index.md
@@ -44,6 +44,7 @@
     </category>
   </category>
   <category name="Literales">
+    <block type="logic_boolean"></block>
     <block type="math_number"></block>
     <block type="text"></block>
     <block type="list"></block>

--- a/src/functions.js
+++ b/src/functions.js
@@ -49,13 +49,11 @@ function buildFuctionBlockWith(name, functionType, cb) {
       reduceBlock(this)(this.getResultBlock())
     },
     generateContextMenu: function() {
-      const even = this
-      const reduceOption = {
+      return [{
         text: "Reducir",
-        callback: even.reduce.bind(even),
+        callback: this.reduce.bind(this),
         enabled: !blockType(this).isFunctionType(),
-      }
-      return [reduceOption].concat(this.__proto__.generateContextMenu.bind(this)())
+      }, ...this.__proto__.generateContextMenu.bind(this)()]
     }
   }
 }
@@ -97,7 +95,7 @@ const reduceBlock = expandedBlock => reducedBlock => {
         replace(reducedBlock)(restoredOldBlock)
       },
       enabled: true
-    }].concat(reducedBlock.__proto__.generateContextMenu.bind(this)())
+    }, ...reducedBlock.__proto__.generateContextMenu.bind(this)()]
   }
 
   replace(expandedBlock)(reducedBlock)

--- a/src/functions.js
+++ b/src/functions.js
@@ -48,17 +48,21 @@ function buildFuctionBlockWith(name, functionType, cb) {
     reduce() {
       let newBlock = null
       if(this.type == 'even') {
-        newBlock = this.workspace.newBlock("logic_boolean")
         const evenResult = this.getChildren()[0].getFieldValue("NUM") % 2 == 0
+        newBlock = this.workspace.newBlock("logic_boolean")
         newBlock.setFieldValue(evenResult ? "TRUE" : "FALSE", "BOOL")
       } else if (this.type == 'not') {
-        newBlock = this.workspace.newBlock("logic_boolean")
         const notResult = this.getChildren()[0].getFieldValue("BOOL") == "TRUE"
+        newBlock = this.workspace.newBlock("logic_boolean")
         newBlock.setFieldValue(notResult ? "FALSE" : "TRUE", "BOOL")
-      } else {
+      } else if (this.type == 'id') {
         const xmlBlock = Blockly.Xml.blockToDom(this.getChildren()[0])
         const copiedBlock = Blockly.Xml.domToBlock(xmlBlock, this.workspace)
         newBlock = copiedBlock
+      } else {
+        const lengthResult = this.getChildren()[0].getFieldValue("TEXT").length
+        newBlock = this.workspace.newBlock("math_number")
+        newBlock.setFieldValue(lengthResult, "NUM")
       }
       reduceBlock(this)(newBlock)
     },

--- a/src/functions.js
+++ b/src/functions.js
@@ -135,6 +135,7 @@ const allArgBlocks = block =>
   Array(block.inputList.length).fill().map((_, i) => argBlock(block, i))
 
 const resultFieldValue = (block, field) => {
+  // TODO: Ver qué onda la aplicación parcial, donde hay atributos que están en el bloque y otros que llegar como argumento.
   const reduction = block.getReduction().block
   const value = reduction.getFieldValue(field)
   if (reduction != block) { reduction.dispose() } // Dispose intermediate result blocks

--- a/src/functions.js
+++ b/src/functions.js
@@ -252,3 +252,6 @@ Blockly.Blocks["math_number"].outputType = createType("Number")
 
 Blockly.Blocks["text"].outputType = createType("String")
 Blockly.Blocks["text"].onchange = function (event) { onChangeValue.bind(this)(event) }
+
+Blockly.Blocks["logic_boolean"].outputType = createType("Boolean")
+Blockly.Blocks["logic_boolean"].onchange = function (event) { onChangeValue.bind(this)(event) }

--- a/src/functions.js
+++ b/src/functions.js
@@ -210,7 +210,16 @@ buildFuctionBlock({
 buildInfixFuctionBlock(["at", "!!"], [newListType("a"), "Number", "a"])
 buildFuctionBlock({
   name: "any",
-  type: [["a", "Boolean"], newListType("a"), "Boolean"]
+  type: [["a", "Boolean"], newListType("a"), "Boolean"],
+  getResultBlock: function (condition, list) {
+    const result = allListElements(list).some(e => {
+      const booleanBlock = condition.getReduction(e).block
+      const bul = getBooleanValue(booleanBlock)
+      booleanBlock.dispose() // Dispose intermediate result blocks
+      return bul
+    })
+    return { block: newBoolean(this.workspace, result) }
+  }
 })
 buildFuctionBlock({
   name: "all",

--- a/src/functions.js
+++ b/src/functions.js
@@ -134,8 +134,12 @@ const argBlock = (block, arg = 0) => {
 const allArgBlocks = block =>
   Array(block.inputList.length).fill().map((_, i) => argBlock(block, i))
 
-const resultFieldValue = (block, field) =>
-  block.getReduction().block.getFieldValue(field)
+const resultFieldValue = (block, field) => {
+  const reduction = block.getReduction().block
+  const value = reduction.getFieldValue(field)
+  if (reduction != block) { reduction.dispose() } // Dispose intermediate result blocks
+  return value
+}
 
 const argFieldValue = (block, arg = 0) => field =>
   resultFieldValue(argBlock(block, arg), field)

--- a/src/functions.js
+++ b/src/functions.js
@@ -51,10 +51,14 @@ function buildFuctionBlockWith(name, functionType, cb) {
         newBlock = this.workspace.newBlock("logic_boolean")
         const evenResult = this.getChildren()[0].getFieldValue("NUM") % 2 == 0
         newBlock.setFieldValue(evenResult ? "TRUE" : "FALSE", "BOOL")
-      } else {
+      } else if (this.type == 'not') {
         newBlock = this.workspace.newBlock("logic_boolean")
         const notResult = this.getChildren()[0].getFieldValue("BOOL") == "TRUE"
         newBlock.setFieldValue(notResult ? "FALSE" : "TRUE", "BOOL")
+      } else {
+        const xmlBlock = Blockly.Xml.blockToDom(this.getChildren()[0])
+        const copiedBlock = Blockly.Xml.domToBlock(xmlBlock, this.workspace)
+        newBlock = copiedBlock
       }
       reduceBlock(this)(newBlock)
     },

--- a/src/functions.js
+++ b/src/functions.js
@@ -105,7 +105,10 @@ function decorateInit(block, initExtension) {
 }
 
 const reduceBlock = expandedBlock => reducedBlock => {
+  // Result blocks are not editable
   reducedBlock.setEditable(false)
+  reducedBlock.getChildren().forEach(child => child.setEditable(false))
+
   expandedBlockAsXml = Blockly.Xml.blockToDom(expandedBlock)
   reducedBlock.generateContextMenu = function () {
     return [{
@@ -126,6 +129,10 @@ const replace = oldBlock => newBlock => {
   newBlock.moveTo(oldBlock.getRelativeToSurfaceXY())
   oldBlock.dispose()
   newBlock.render()
+  newBlock.getChildren().forEach(child => {
+    child.initSvg()
+    child.render()
+  })
 }
 
 const newListType = elementType => new ListType(createType(elementType))
@@ -233,7 +240,11 @@ buildFuctionBlock({
 })
 buildFuctionBlock({
   name: "map",
-  type: [["a", "b"], newListType("a"), newListType("b")]
+  type: [["a", "b"], newListType("a"), newListType("b")],
+  getResultBlock: function (transform, list) {
+    const result = allListElements(list).map(e => transform.getReduction(e).block)
+    return { block: newList(this.workspace, result) }
+  }
 })
 buildFuctionBlock({
   name: "maximum",

--- a/src/functions.js
+++ b/src/functions.js
@@ -130,30 +130,24 @@ buildFuctionBlock({
   name: "even",
   type: ["Number", "Boolean"],
   getResultBlock: function () {
-    const evenResult = argFieldValue(this)("NUM") % 2 == 0
-    newBlock = this.workspace.newBlock("logic_boolean")
-    newBlock.setFieldValue(evenResult ? "TRUE" : "FALSE", "BOOL")
-    return { block: newBlock }
+    const result = argFieldValue(this)("NUM") % 2 == 0
+    return { block: newBoolean(this.workspace, result) }
   }
 })
 buildFuctionBlock({
   name: "not",
   type: ["Boolean", "Boolean"],
   getResultBlock: function () {
-    const notResult = argFieldValue(this)("BOOL") == "TRUE"
-    newBlock = this.workspace.newBlock("logic_boolean")
-    newBlock.setFieldValue(notResult ? "FALSE" : "TRUE", "BOOL")
-    return { block: newBlock }
+    const result = argFieldValue(this)("BOOL") == "FALSE"
+    return { block: newBoolean(this.workspace, result) }
   }
 })
 buildFuctionBlock({
   name: "length",
   type: ["String", "Number"],
   getResultBlock: function () {
-    const lengthResult = argFieldValue(this)("TEXT").length
-    newBlock = this.workspace.newBlock("math_number")
-    newBlock.setFieldValue(lengthResult, "NUM")
-    return { block: newBlock }
+    const result = argFieldValue(this)("TEXT").length
+    return { block: newNumber(this.workspace, result) }
   }
 })//TODO: List(Char)
 buildFuctionBlock({
@@ -162,11 +156,9 @@ buildFuctionBlock({
   getResultBlock: function () {
     const position = argFieldValue(this, 0)("NUM")
     const string = argFieldValue(this, 1)("TEXT")
-    const charAtResult = string[position]
-    if (charAtResult != null) {
-      newBlock = this.workspace.newBlock("text")
-      newBlock.setFieldValue(charAtResult, "TEXT")
-      return { block: newBlock }
+    const result = string[position]
+    if (result != null) {
+      return { block: newString(this.workspace, result) }
     } else {
       return ({ error: "Out of bounds position" })
     }

--- a/src/functions.js
+++ b/src/functions.js
@@ -52,7 +52,7 @@ function buildFuctionBlockWith(name, functionType, cb) {
       return [{
         text: "Reducir",
         callback: this.reduce.bind(this),
-        enabled: !blockType(this).isFunctionType(),
+        enabled: !blockType(this).isFunctionType() && this.getResultBlock,
       }, ...this.__proto__.generateContextMenu.bind(this)()]
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -57,12 +57,11 @@ const organizeList = block => {
     block.inputList
       .filter(isEmptyBlockInput)
       .forEach(removeInput(block))
-    const newInputName = `ELEMENT${block.inputIndex++}`
-    appendNewInputList(block, newInputName)
+    appendNewInputList(block)
   }
 }
 
-const appendNewInputList = (block, inputName) => {
+const appendNewInputList = (block, inputName = `ELEMENT${block.inputIndex++}`) => {
   block.appendValueInput(inputName)
     .appendField(",")
     .inputType = createType("a")

--- a/src/utils.js
+++ b/src/utils.js
@@ -29,6 +29,12 @@ const newBlockWithFields = (workspace, type, fields = {}) => {
   return newBlock
 }
 
+const newFunction = (workspace, type, ...args) => {
+  const block = newBlockWithFields(workspace, type)
+  args.forEach((arg, i) => connect(block, arg, i))
+  return block
+}
+
 const newBoolean = (workspace, value) =>
   newBlockWithFields(workspace, "logic_boolean", { "BOOL": value ? "TRUE" : "FALSE" })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,7 +31,7 @@ const newBlockWithFields = (workspace, type, fields = {}) => {
 
 const newFunction = (workspace, type, ...args) => {
   const block = newBlockWithFields(workspace, type)
-  args.forEach((arg, i) => connect(block, arg, i))
+  args.forEach((arg, i) => { if (arg) { connect(block, arg, i) } })
   return block
 }
 
@@ -43,6 +43,9 @@ const newNumber = (workspace, value) =>
 
 const newString = (workspace, value) =>
   newBlockWithFields(workspace, "text", { "TEXT": value })
+
+// INTERPRETER
+const getBooleanValue = block => resultFieldValue(block, "BOOL") == "TRUE"
 
 // LIST
 const isOrganizedList = block =>
@@ -66,6 +69,11 @@ const appendNewInputList = (block, inputName) => {
   block.moveInputBefore(inputName, "CLOSE")
   renameField(block.inputList[0], "[")
 }
+
+const allListElements = blockList =>
+  blockList.inputList
+    .filter(input => input.name.includes("ELEMENT") && input.connection.targetBlock())
+    .map(input => input.connection.targetBlock())
 // Blockly
 
 // Iterables

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,12 @@ const renameField = (input, name) => {
 
 const copyBlock = (workspace, block) => Blockly.Xml.domToBlock(Blockly.Xml.blockToDom(block), workspace)
 
+const connectInputBlock = (block, parameterBlock, inputIndex) => {
+  block.inputList
+    .filter(isBlockInput)[inputIndex]
+    .connection.connect(parameterBlock.outputConnection)
+}
+
 // Block creation
 const newBlockWithFields = (workspace, type, fields = {}) => {
   const newBlock = workspace.newBlock(type)
@@ -43,6 +49,15 @@ const newNumber = (workspace, value) =>
 
 const newString = (workspace, value) =>
   newBlockWithFields(workspace, "text", { "TEXT": value })
+
+const newList = (workspace, elementBlocks) => {
+  const list = workspace.newBlock('list')
+  elementBlocks.forEach((e, i) => {
+    appendNewInputList(list)
+    connectInputBlock(list, e, i)
+  })
+  return list
+}
 
 // INTERPRETER
 const getBooleanValue = block => resultFieldValue(block, "BOOL") == "TRUE"

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,25 @@ const renameField = (input, name) => {
   input.appendField(name)
 }
 
+// Block creation
+const newBlockWithFields = (workspace, type, fields = {}) => {
+  const newBlock = workspace.newBlock(type)
+  Object.entries(fields).forEach(([fieldName, value]) => {
+    newBlock.setFieldValue(value, fieldName);
+  });
+  return newBlock
+}
+
+const newBoolean = (workspace, value) =>
+  newBlockWithFields(workspace, "logic_boolean", { "BOOL": value ? "TRUE" : "FALSE" })
+
+const newNumber = (workspace, value) =>
+  newBlockWithFields(workspace, "math_number", { "NUM": value })
+
+const newString = (workspace, value) =>
+  newBlockWithFields(workspace, "text", { "TEXT": value })
+
+// LIST
 const isOrganizedList = block =>
   block.inputList.filter(isEmptyBlockInput).length === 1 &&
   isEmptyBlockInput(last(block.inputList.filter(isBlockInput)))

--- a/src/utils.js
+++ b/src/utils.js
@@ -18,6 +18,8 @@ const renameField = (input, name) => {
   input.appendField(name)
 }
 
+const copyBlock = (workspace, block) => Blockly.Xml.domToBlock(Blockly.Xml.blockToDom(block), workspace)
+
 // Block creation
 const newBlockWithFields = (workspace, type, fields = {}) => {
   const newBlock = workspace.newBlock(type)

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -53,3 +53,13 @@ const assertColor = (block, color) => {
   assert.equal(colorShow(block), color)
 }
 // Assertions
+
+// Block creation
+
+const newBlockWithFields = (workspace, type, fields = {}) => {
+  const newBlock = workspace.newBlock(type)
+  Object.entries(fields).forEach(([fieldName, value]) => {
+    newBlock.setFieldValue(value, fieldName);
+  });
+  return newBlock
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -23,7 +23,7 @@ const onWorkspace = (name, test) => {
 }
 
 const connect = (block, parameterBlock, inputIndex = 0) => {
-  block.inputList[inputIndex].connection.connect(parameterBlock.outputConnection)
+  connectInputBlock(block, parameterBlock, inputIndex)
   forceBlocklyEvents()
   forceBlocklyEvents() // ??
 }
@@ -54,14 +54,3 @@ const assertColor = (block, color) => {
 }
 // Assertions
 
-
-// TODO: Move to Utils, think better strategy for list block instantiantion
-
-const newList = (workspace, elementBlocks) => {
-  const list = workspace.newBlock('list')
-  elementBlocks.forEach((e, i) => {
-    appendNewInputList(list)
-    connect(list, e, i)
-  })
-  return list
-}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -54,3 +54,14 @@ const assertColor = (block, color) => {
 }
 // Assertions
 
+
+// TODO: Move to Utils, think better strategy for list block instantiantion
+
+const newList = (workspace, elementBlocks) => {
+  const list = workspace.newBlock('list')
+  elementBlocks.forEach((e, i) => {
+    appendNewInputList(list)
+    connect(list, e, i)
+  })
+  return list
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -54,12 +54,3 @@ const assertColor = (block, color) => {
 }
 // Assertions
 
-// Block creation
-
-const newBlockWithFields = (workspace, type, fields = {}) => {
-  const newBlock = workspace.newBlock(type)
-  Object.entries(fields).forEach(([fieldName, value]) => {
-    newBlock.setFieldValue(value, fieldName);
-  });
-  return newBlock
-}

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -129,5 +129,35 @@ describe('Reducing expressions', () => {
         })
       })
     })
+
+    describe("charAt", () => {
+      onWorkspace("when it is passed a valid position of an string and a string, it returns the character at that position", workspace => {
+        const charAt = workspace.newBlock('charAt')
+        const hello = newBlockWithFields(workspace, 'text', {TEXT:"Hello"})
+        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
+        connect(charAt, zero, 0)
+        connect(charAt, hello, 1)
+
+        charAt.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, charAt, newBlock => {
+          return newBlock.type == 'text' && newBlock.getFieldValue("TEXT") == "H"
+        })
+      })
+
+      onWorkspace("when it is passed an invalid position of an string and a string, it fails without reducing anything", workspace => {
+        const charAt = workspace.newBlock('charAt')
+        const hello = newBlockWithFields(workspace, 'text', {TEXT:"Hello"})
+        const six = newBlockWithFields(workspace, 'math_number', {NUM:6})
+        connect(charAt, six, 0)
+        connect(charAt, hello, 1)
+
+        charAt.reduce()
+
+        assert.exists(workspace.getBlockById(charAt.id))
+        assert.exists(workspace.getBlockById(hello.id))
+        assert.exists(workspace.getBlockById(six.id))
+      })
+    })
   })
 })

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -160,6 +160,18 @@ describe('Reducing expressions', () => {
         assertEqualReductionBlock(anyEven13, newBoolean(workspace, false))
       })
     })
+
+    describe('map', () => {
+      onWorkspace('reduction works', workspace => {
+        const numbers = [1, 3].map(n => newNumber(workspace, n))
+        const words = ["a", "asd"].map(s => newString(workspace, s))
+        const mapLengthWords = newFunction(workspace, 'map',
+          newFunction(workspace, 'length'), newList(workspace, words)
+        )
+        assertEqualReductionBlock(mapLengthWords, newList(workspace, numbers))
+      })
+    })
+
   })
 })
 
@@ -185,4 +197,8 @@ const assertEqualBlocks = (block, expectedBlock) => {
     assert.equal(field.name, expectedField.name)
     assert.equal(field.getValue(), expectedField.getValue())
   })
+  zip(
+    block.getChildren(),
+    expectedBlock.getChildren()
+  ).forEach(([block, expectedBlock]) => assertEqualBlocks(block, expectedBlock))
 }

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -89,5 +89,19 @@ describe('Reducing expressions', () => {
         })
       })
     })
+
+    describe('id', () => {
+      onWorkspace('when it is applied any paramter it reduces to that parameter', workspace => {
+        const id = workspace.newBlock('id')
+        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
+        connect(id, zero)
+
+        id.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, id, (newBlock) => {
+          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
+        })
+      })
+    })
   })
 })

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -32,6 +32,36 @@ describe('Reducing expressions', () => {
     assertEqualBlocksInWorkspace(workspace, newBoolean(workspace, false))
   })
 
+  onWorkspace('reducing partial applied function arguments', workspace => {
+    const charAt0 = newFunction(workspace, 'charAt', newNumber(workspace, 0))
+    const legthCharAt0ASD = newFunction(workspace, 'composition',
+      newFunction(workspace, 'length'), charAt0, newString(workspace, "ASD")
+    )
+
+    legthCharAt0ASD.reduce()
+
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'composition')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'length')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'charAt')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'text')
+    assertEqualBlocksInWorkspace(workspace, newNumber(workspace, 1))
+  })
+
+  onWorkspace('reducing positional partial applied function arguments', workspace => {
+    const charAtASD = newFunction(workspace, 'charAt', undefined, newString(workspace, "ASD"))
+    const legthCharAt0ASD = newFunction(workspace, 'composition',
+      newFunction(workspace, 'length'), charAtASD, newNumber(workspace, 0)
+    )
+
+    legthCharAt0ASD.reduce()
+
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'composition')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'length')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'charAt')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'text')
+    assertEqualBlocksInWorkspace(workspace, newNumber(workspace, 1))
+  })
+
   describe('Reduction results', () => {
     describe('even', () => {
       onWorkspace('When it is applied an even number it reduces to true', workspace => {

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -135,6 +135,31 @@ describe('Reducing expressions', () => {
         assertEqualReductionBlock(odd0, newBoolean(workspace, false))
       })
     })
+
+    describe('any', () => {
+      onWorkspace('on empty list', workspace => {
+        const anyEvenEmpty = newFunction(workspace, 'any',
+          newFunction(workspace, 'even'), newList(workspace, [])
+        )
+        assertEqualReductionBlock(anyEvenEmpty, newBoolean(workspace, false))
+      })
+
+      onWorkspace('When any element apply', workspace => {
+        const numbers = [1, 2].map(n => newNumber(workspace, n))
+        const anyEven12 = newFunction(workspace, 'any',
+          newFunction(workspace, 'even'), newList(workspace, numbers)
+        )
+        assertEqualReductionBlock(anyEven12, newBoolean(workspace, true))
+      })
+
+      onWorkspace('When no element apply', workspace => {
+        const numbers = [1, 3].map(n => newNumber(workspace, n))
+        const anyEven13 = newFunction(workspace, 'any',
+          newFunction(workspace, 'even'), newList(workspace, numbers)
+        )
+        assertEqualReductionBlock(anyEven13, newBoolean(workspace, false))
+      })
+    })
   })
 })
 

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -116,6 +116,18 @@ describe('Reducing expressions', () => {
           return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
         })
       })
+
+      onWorkspace('when it is applied a string it reduces to the amount of characters in the string', workspace => {
+        const length = workspace.newBlock('length')
+        const helloWorld = newBlockWithFields(workspace, 'text', {TEXT:"Hello World!"})
+        connect(length, helloWorld)
+
+        length.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, length, (newBlock) => {
+          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 12
+        })
+      })
     })
   })
 })

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -107,20 +107,6 @@ describe('Reducing expressions', () => {
       })
     })
 
-    describe('id', () => {
-      onWorkspace('when it is applied any paramter it reduces to that parameter', workspace => {
-        const id = workspace.newBlock('id')
-        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
-        connect(id, zero)
-
-        id.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, id, (newBlock) => {
-          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
-        })
-      })
-    })
-
     describe('length', () => {
       onWorkspace('when it is applied an empty string it reduces to 0', workspace => {
         const length = workspace.newBlock('length')
@@ -174,6 +160,38 @@ describe('Reducing expressions', () => {
         assert.exists(workspace.getBlockById(charAt.id))
         assert.exists(workspace.getBlockById(hello.id))
         assert.exists(workspace.getBlockById(six.id))
+      })
+    })
+
+    describe('id', () => {
+      onWorkspace('when it is applied any paramter it reduces to that parameter', workspace => {
+        const id = workspace.newBlock('id')
+        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
+        connect(id, zero)
+
+        id.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, id, (newBlock) => {
+          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
+        })
+      })
+    })
+
+    describe('composition', () => {
+      onWorkspace('reduction works', workspace => {
+        const composition = workspace.newBlock('composition')
+        const not = workspace.newBlock('not')
+        const even = workspace.newBlock('even')
+        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
+        connect(composition, not, 0)
+        connect(composition, even, 1)
+        connect(composition, zero, 2)
+
+        composition.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, composition, (newBlock) => {
+          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
+        })
       })
     })
   })

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -103,5 +103,19 @@ describe('Reducing expressions', () => {
         })
       })
     })
+
+    describe('length', () => {
+      onWorkspace('when it is applied an empty string it reduces to 0', workspace => {
+        const length = workspace.newBlock('length')
+        const emptyString = workspace.newBlock('text')
+        connect(length, emptyString)
+
+        length.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, length, (newBlock) => {
+          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
+        })
+      })
+    })
   })
 })

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -37,6 +37,23 @@ describe('Reducing expressions', () => {
     })
   })
 
+  onWorkspace('reducing applied function works for expresion arguments', workspace => {
+    const not = workspace.newBlock('not')
+    const even = workspace.newBlock('even')
+    const zero = workspace.newBlock('math_number')
+    connect(even, zero)
+    connect(not, even)
+
+    not.reduce()
+
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'not')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'even')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'math_number')
+    assertAnyBlockInWorkspaceSatisfies(workspace, (block) => {
+      return block.type == 'logic_boolean' && block.getFieldValue("BOOL") == "FALSE"
+    })
+  })
+
   describe('Reduction results', () => {
     describe('even', () => {
       onWorkspace('When it is applied an even number it reduces to true', workspace => {

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const assertBlockWithTypeDoesNotExistInWorkspace = (workspace, type) =>
+  assert.isEmpty(workspace.getBlocksByType(type))
+
+const assertAnyBlockInWorkspaceSatisfies = (workspace, condition) => {
+  assert.exists(workspace.getAllBlocks().find(condition))
+}
+
+const assertReplacedByBlockThatSatisfies = (workspace, oldBlock, newBlockCondition) => {
+  const oldBlockWithChildren = [oldBlock, ...oldBlock.getChildren()]
+  oldBlockWithChildren.forEach(block => assert.notExists(workspace.getBlockById(block.id)))
+
+  assertAnyBlockInWorkspaceSatisfies(workspace, newBlockCondition)
+}
+
+describe('Reducing expressions', () => {
+  onWorkspace('reducing an unapplied function fails and keeps it in the workspace', workspace => {
+    const even = workspace.newBlock('even')
+
+    assert.throws(() => even.reduce())
+
+    assertAnyBlockInWorkspaceSatisfies(workspace, ({type}) => type == 'even')
+  })
+
+  onWorkspace('reducing an applied function removes it and its parameter from workspace and adds result to workspace', workspace => {
+    const even = workspace.newBlock('even')
+    const zero = workspace.newBlock('math_number')
+    connect(even, zero)
+
+    even.reduce()
+
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'even')
+    assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'math_number')
+    assertAnyBlockInWorkspaceSatisfies(workspace, (block) => {
+      return block.type == 'logic_boolean' && block.getFieldValue("BOOL") == "TRUE"
+    })
+  })
+
+  describe('Reduction results', () => {
+    describe('even', () => {
+      onWorkspace('When it is applied an even number it reduces to true', workspace => {
+        const even = workspace.newBlock('even')
+        const zero = newBlockWithFields(workspace, 'math_number', {NUM: 0})
+        connect(even, zero)
+
+        even.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, even, (newBlock) => {
+          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "TRUE"
+        })
+      }),
+
+      onWorkspace('When it applied an odd number it reduces to false', workspace => {
+        const even = workspace.newBlock('even')
+        const one = newBlockWithFields(workspace, 'math_number', {NUM: 1})
+        connect(even, one)
+
+        even.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, even, (newBlock) => {
+          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
+        })
+      })
+    })
+
+    describe('not', () => {
+      onWorkspace('When it is applied true it reduces to false', workspace => {
+        const not = workspace.newBlock('not')
+        const tru = newBlockWithFields(workspace, 'logic_boolean', {BOOL:"TRUE"})
+        connect(not, tru)
+
+        not.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, not, newBlock => {
+          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
+        })
+      })
+
+      onWorkspace('When it is applied false it reduces to true', workspace => {
+        const not = workspace.newBlock('not')
+        const fols = newBlockWithFields(workspace, 'logic_boolean', {BOOL:"FALSE"})
+        connect(not, fols)
+
+        not.reduce()
+
+        assertReplacedByBlockThatSatisfies(workspace, not, newBlock => {
+          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "TRUE"
+        })
+      })
+    })
+  })
+})

--- a/test/reducingSpec.js
+++ b/test/reducingSpec.js
@@ -1,163 +1,90 @@
 'use strict'
 
-const assertBlockWithTypeDoesNotExistInWorkspace = (workspace, type) =>
-  assert.isEmpty(workspace.getBlocksByType(type))
-
-const assertAnyBlockInWorkspaceSatisfies = (workspace, condition) => {
-  assert.exists(workspace.getAllBlocks().find(condition))
-}
-
-const assertReplacedByBlockThatSatisfies = (workspace, oldBlock, newBlockCondition) => {
-  const oldBlockWithChildren = [oldBlock, ...oldBlock.getChildren()]
-  oldBlockWithChildren.forEach(block => assert.notExists(workspace.getBlockById(block.id)))
-
-  assertAnyBlockInWorkspaceSatisfies(workspace, newBlockCondition)
-}
-
 describe('Reducing expressions', () => {
   onWorkspace('reducing an unapplied function fails and keeps it in the workspace', workspace => {
     const even = workspace.newBlock('even')
 
     assert.throws(() => even.reduce())
 
-    assertAnyBlockInWorkspaceSatisfies(workspace, ({type}) => type == 'even')
+    assertAnyBlockInWorkspaceSatisfies(workspace, ({ type }) => type == 'even')
   })
 
   onWorkspace('reducing an applied function removes it and its parameter from workspace and adds result to workspace', workspace => {
-    const even = workspace.newBlock('even')
-    const zero = workspace.newBlock('math_number')
-    connect(even, zero)
+    const even0 = newFunction(workspace, 'even', newNumber(workspace, 0))
 
-    even.reduce()
+    even0.reduce()
 
     assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'even')
     assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'math_number')
-    assertAnyBlockInWorkspaceSatisfies(workspace, (block) => {
-      return block.type == 'logic_boolean' && block.getFieldValue("BOOL") == "TRUE"
-    })
+    assertEqualBlocksInWorkspace(workspace, newBoolean(workspace, true))
   })
 
   onWorkspace('reducing applied function works for expresion arguments', workspace => {
-    const not = workspace.newBlock('not')
-    const even = workspace.newBlock('even')
-    const zero = workspace.newBlock('math_number')
-    connect(even, zero)
-    connect(not, even)
+    const notEven0 = newFunction(workspace, 'not',
+      newFunction(workspace, 'even', newNumber(workspace, 0))
+    )
 
-    not.reduce()
+    notEven0.reduce()
 
     assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'not')
     assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'even')
     assertBlockWithTypeDoesNotExistInWorkspace(workspace, 'math_number')
-    assertAnyBlockInWorkspaceSatisfies(workspace, (block) => {
-      return block.type == 'logic_boolean' && block.getFieldValue("BOOL") == "FALSE"
-    })
+    assertEqualBlocksInWorkspace(workspace, newBoolean(workspace, false))
   })
 
   describe('Reduction results', () => {
     describe('even', () => {
       onWorkspace('When it is applied an even number it reduces to true', workspace => {
-        const even = workspace.newBlock('even')
-        const zero = newBlockWithFields(workspace, 'math_number', {NUM: 0})
-        connect(even, zero)
-
-        even.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, even, (newBlock) => {
-          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "TRUE"
-        })
-      }),
+        const even0 = newFunction(workspace, 'even', newNumber(workspace, 0))
+        assertEqualReductionBlock(even0, newBoolean(workspace, true))
+      })
 
       onWorkspace('When it applied an odd number it reduces to false', workspace => {
-        const even = workspace.newBlock('even')
-        const one = newBlockWithFields(workspace, 'math_number', {NUM: 1})
-        connect(even, one)
-
-        even.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, even, (newBlock) => {
-          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
-        })
+        const even1 = newFunction(workspace, 'even', newNumber(workspace, 1))
+        assertEqualReductionBlock(even1, newBoolean(workspace, false))
       })
     })
 
     describe('not', () => {
       onWorkspace('When it is applied true it reduces to false', workspace => {
-        const not = workspace.newBlock('not')
-        const tru = newBlockWithFields(workspace, 'logic_boolean', {BOOL:"TRUE"})
-        connect(not, tru)
-
-        not.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, not, newBlock => {
-          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
-        })
+        const notTrue = newFunction(workspace, 'not', newBoolean(workspace, true))
+        assertEqualReductionBlock(notTrue, newBoolean(workspace, false))
       })
 
       onWorkspace('When it is applied false it reduces to true', workspace => {
-        const not = workspace.newBlock('not')
-        const fols = newBlockWithFields(workspace, 'logic_boolean', {BOOL:"FALSE"})
-        connect(not, fols)
-
-        not.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, not, newBlock => {
-          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "TRUE"
-        })
+        const notFalse = newFunction(workspace, 'not', newBoolean(workspace, false))
+        assertEqualReductionBlock(notFalse, newBoolean(workspace, true))
       })
     })
 
     describe('length', () => {
       onWorkspace('when it is applied an empty string it reduces to 0', workspace => {
-        const length = workspace.newBlock('length')
-        const emptyString = workspace.newBlock('text')
-        connect(length, emptyString)
-
-        length.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, length, (newBlock) => {
-          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
-        })
+        const lengthEmpty = newFunction(workspace, 'length', newString(workspace, ""))
+        assertEqualReductionBlock(lengthEmpty, newNumber(workspace, 0))
       })
 
       onWorkspace('when it is applied a string it reduces to the amount of characters in the string', workspace => {
-        const length = workspace.newBlock('length')
-        const helloWorld = newBlockWithFields(workspace, 'text', {TEXT:"Hello World!"})
-        connect(length, helloWorld)
-
-        length.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, length, (newBlock) => {
-          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 12
-        })
+        const lengthHelloWorld = newFunction(workspace, 'length', newString(workspace, "Hello World!"))
+        assertEqualReductionBlock(lengthHelloWorld, newNumber(workspace, 12))
       })
     })
 
     describe("charAt", () => {
       onWorkspace("when it is passed a valid position of an string and a string, it returns the character at that position", workspace => {
-        const charAt = workspace.newBlock('charAt')
-        const hello = newBlockWithFields(workspace, 'text', {TEXT:"Hello"})
-        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
-        connect(charAt, zero, 0)
-        connect(charAt, hello, 1)
-
-        charAt.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, charAt, newBlock => {
-          return newBlock.type == 'text' && newBlock.getFieldValue("TEXT") == "H"
-        })
+        const charAt0Hello = newFunction(workspace, 'charAt',
+          newNumber(workspace, 0), newString(workspace, "Hello")
+        )
+        assertEqualReductionBlock(charAt0Hello, newString(workspace, "H"))
       })
 
       onWorkspace("when it is passed an invalid position of an string and a string, it fails without reducing anything", workspace => {
-        const charAt = workspace.newBlock('charAt')
-        const hello = newBlockWithFields(workspace, 'text', {TEXT:"Hello"})
-        const six = newBlockWithFields(workspace, 'math_number', {NUM:6})
-        connect(charAt, six, 0)
-        connect(charAt, hello, 1)
+        const six = newNumber(workspace, 6)
+        const hello = newString(workspace, "Hello")
+        const charAt0Hello = newFunction(workspace, 'charAt', six, hello)
 
-        charAt.reduce()
+        charAt0Hello.reduce()
 
-        assert.exists(workspace.getBlockById(charAt.id))
+        assert.exists(workspace.getBlockById(charAt0Hello.id))
         assert.exists(workspace.getBlockById(hello.id))
         assert.exists(workspace.getBlockById(six.id))
       })
@@ -165,34 +92,42 @@ describe('Reducing expressions', () => {
 
     describe('id', () => {
       onWorkspace('when it is applied any paramter it reduces to that parameter', workspace => {
-        const id = workspace.newBlock('id')
-        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
-        connect(id, zero)
-
-        id.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, id, (newBlock) => {
-          return newBlock.type == 'math_number' && newBlock.getFieldValue("NUM") == 0
-        })
+        const id0 = newFunction(workspace, 'id', newNumber(workspace, 0))
+        assertEqualReductionBlock(id0, newNumber(workspace, 0))
       })
     })
 
     describe('composition', () => {
       onWorkspace('reduction works', workspace => {
-        const composition = workspace.newBlock('composition')
-        const not = workspace.newBlock('not')
-        const even = workspace.newBlock('even')
-        const zero = newBlockWithFields(workspace, 'math_number', {NUM:0})
-        connect(composition, not, 0)
-        connect(composition, even, 1)
-        connect(composition, zero, 2)
-
-        composition.reduce()
-
-        assertReplacedByBlockThatSatisfies(workspace, composition, (newBlock) => {
-          return newBlock.type == 'logic_boolean' && newBlock.getFieldValue("BOOL") == "FALSE"
-        })
+        const odd0 = newFunction(workspace, 'composition',
+          newFunction(workspace, 'not'), newFunction(workspace, 'even'), newNumber(workspace, 0)
+        )
+        assertEqualReductionBlock(odd0, newBoolean(workspace, false))
       })
     })
   })
 })
+
+const assertBlockWithTypeDoesNotExistInWorkspace = (workspace, type) =>
+  assert.isEmpty(workspace.getBlocksByType(type))
+
+const assertAnyBlockInWorkspaceSatisfies = (workspace, condition) => {
+  assert.exists(workspace.getAllBlocks().find(condition))
+}
+
+const assertEqualBlocksInWorkspace = (workspace, expectedBlock) =>
+  assertEqualBlocks(workspace.getTopBlocks()[0], expectedBlock)
+
+const assertEqualReductionBlock = (block, expectedBlock) =>
+  assertEqualBlocks(block.getReduction().block, expectedBlock)
+
+const assertEqualBlocks = (block, expectedBlock) => {
+  assert.equal(block.type, expectedBlock.type)
+  zip(
+    block.inputList.flatMap(input => input.fieldRow),
+    expectedBlock.inputList.flatMap(input => input.fieldRow)
+  ).forEach(([field, expectedField]) => {
+    assert.equal(field.name, expectedField.name)
+    assert.equal(field.getValue(), expectedField.getValue())
+  })
+}

--- a/test/test.html
+++ b/test/test.html
@@ -29,6 +29,7 @@
     <script src="typeSpec.js"></script>
     <script src="colorSpec.js"></script>
     <script src="constraintSolvingSpec.js"></script>
+    <script src="reducingSpec.js"></script>
     <script>mocha.run();</script>
 </body>
 


### PR DESCRIPTION
Queremos poder reducir expresiones convirtiendo bloques con parametros aplicados en bloques que representan el resultado.

La forma en la que esta resuelto esto es:
- Agregando una nueva opción a los menues de los bloques que representan funciones, esa opción es **Reducir**, y lo que hace es reemplazar al bloque y sus hijos por el resultado. Esa opción solo esta disponible para algunos bloques y solo cuando tienen todos los parámetros aplicados.
- Cuando se crea un bloque reducido, también tiene una opción nueva en el menu, **Expandir**, que sirve para llegar al bloque del que vino. Nota: no se puede volver de una reducción de una reducción al valor original aun :/
- Los tipos de bloque que se pueden reducir tienen que implementar `getResultBlock`, que devuelve el bloque que representaría al resultado.
- En caso de error (puede pasar con funciones parciales como charAt), estoy haciendo que `getResult` devuelva un objeto que puede o tener un bloque o un error. Si tiene un error se lo delego a un "errorReporter" (que lo creé en este PR), y el comportamiento actual del errorReporter es tirar un alert feito con el mensaje del error, pero pensaba que después podemos modificar como mostrar los errores tocando ese objeto.
- Por ahora la lógica de `getResultBlock` está muy acoplada a como es la estructura de los bloques, un posible refactor creo que sería delegar de alguna manera en cada bloque hijo que sepa devolver el valor que representa para que el bloque padre no tenga que saber como accederlo (más que nada porque si no siento que con las funciones de orden superior se va a hacer bastante turbina).

Agregué tests para todos los bloques a los que les implementé la forma de reducirse.

Ejemplos:

![reduceExamples](https://user-images.githubusercontent.com/11432672/82160218-1c7b0100-986a-11ea-8480-cd707b096f72.gif)
