### PR TITLE
se cambio la formula para el calculo del color de los tipos estructurales

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -22,3 +22,11 @@ const colorShow = (block) => {
   if (block.getParent()) return colorShow(block.getParent())
   return colorType(block)
 }
+
+const combineColors = (colorsList) => {
+  var output = 0 
+    for(var i=1 ; i <= colorsList.length ; i++){
+      output = output + colorsList[i-1]*i
+     }
+    return output % 360
+}

--- a/src/colors.js
+++ b/src/colors.js
@@ -1,9 +1,9 @@
-const defaultColor = 360 / 5
+const defaultColor = 360 / 5 //72
 
 const colorTypes = {
-  'Boolean': 360 / 5 * 2,
-  'Number': 360 / 5 * 3,
-  'String': 360 / 5 * 4,
+  'Boolean': 360 / 5 * 2, //144
+  'Number': 360 / 5 * 3, //216
+  'String': 360 / 5 * 4, //288
   'Function': 10,
   'List': 40,
   'Any': defaultColor

--- a/src/typeSystem.js
+++ b/src/typeSystem.js
@@ -80,7 +80,12 @@ class EstructuralType extends Type {
   }
 
   toColor(typeColors) {
-    return this.attributeValues().map(type => type.toColor(typeColors)).reduce(add, colorForType(this.name))
+    const colors = this.attributeValues().map(type => type.toColor(typeColors)) 
+    var output = colorForType(this.name) 
+    for(var i=1 ; i <= colors.length ; i++){
+      output = output + colors[i-1]*i
+     }
+    return output % 360
   }
 }
 

--- a/src/typeSystem.js
+++ b/src/typeSystem.js
@@ -80,12 +80,9 @@ class EstructuralType extends Type {
   }
 
   toColor(typeColors) {
-    const colors = this.attributeValues().map(type => type.toColor(typeColors)) 
-    var output = colorForType(this.name) 
-    for(var i=1 ; i <= colors.length ; i++){
-      output = output + colors[i-1]*i
-     }
-    return output % 360
+    var colorList =  this.attributeValues().map(type => type.toColor(typeColors))
+    colorList = [colorForType(this.name)].concat(colorList)
+    return combineColors(colorList)
   }
 }
 

--- a/test/colorSpec.js
+++ b/test/colorSpec.js
@@ -13,8 +13,8 @@ describe('Colors', () => {
 
   onWorkspace('function color es la suma del producto de los colores de los tipos de acuerdo a su posicion', workspace => {
     const fType = createType(["Number", "Boolean"])
-    
-    assert.equal(typeToColor(fType),(colorForType('Function') + colorForType('Number')*1 + colorForType('Boolean')*2) % 360)
+    var colorList = ['Function','Number','Boolean'].map (colorForType)
+    assert.equal(typeToColor(fType), combineColors(colorList))
     })
 
   onWorkspace('partial applied function color is the same as the color of a function whose type is the same as the the partial applied function s type', workspace => {
@@ -46,16 +46,16 @@ describe('Colors', () => {
 
   onWorkspace('empty list color', workspace => {
     const list = workspace.newBlock('list')
-    assertColor(list, (colorForType('List') + typeToColor(createType('a'))*1) % 360)
+    var colorList = ['List','Any'].map (colorForType)
+    assertColor(list, combineColors(colorList))
   })
 
   onWorkspace('full list color', workspace => {
     const list = workspace.newBlock('list')
     const text = workspace.newBlock('text')
-    
     connect(list, text)
-    //assertColor(list, (Math.pow(typeToColor(String),1) + Math.pow(colorForType('List'),2) ) % 360)
-    assertColor(list, (colorForType('List')+ typeToColor(String)*1)% 360)
+    var colorList = ['List','String'].map (colorForType)
+    assertColor(list, combineColors(colorList))
   })
 
   onWorkspace('distintos colores para funciones con los mismos tipos de parametros pero en distinto orden', workspace => {

--- a/test/colorSpec.js
+++ b/test/colorSpec.js
@@ -11,10 +11,11 @@ describe('Colors', () => {
     assertColor(number, typeToColor(Number))
   })
 
-  onWorkspace('function color is the sum of the color of its inputs types and its output type', workspace => {
-    const even = workspace.newBlock('even')
-    assertColor(even, typeToColor(Number) + typeToColor(Boolean) + colorForType('Function'))
-  })
+  onWorkspace('function color es la suma del producto de los colores de los tipos de acuerdo a su posicion', workspace => {
+    const fType = createType(["Number", "Boolean"])
+    
+    assert.equal(typeToColor(fType),(colorForType('Function') + colorForType('Number')*1 + colorForType('Boolean')*2) % 360)
+    })
 
   onWorkspace('partial applied function color is the same as the color of a function whose type is the same as the the partial applied function s type', workspace => {
     const even = workspace.newBlock('even')
@@ -45,7 +46,7 @@ describe('Colors', () => {
 
   onWorkspace('empty list color', workspace => {
     const list = workspace.newBlock('list')
-    assertColor(list, typeToColor(createType('a')) + colorForType('List'))
+    assertColor(list, (colorForType('List') + typeToColor(createType('a'))*1) % 360)
   })
 
   onWorkspace('full list color', workspace => {
@@ -53,7 +54,16 @@ describe('Colors', () => {
     const text = workspace.newBlock('text')
     
     connect(list, text)
-
-    assertColor(list, typeToColor(String) + colorForType('List'))
+    //assertColor(list, (Math.pow(typeToColor(String),1) + Math.pow(colorForType('List'),2) ) % 360)
+    assertColor(list, (colorForType('List')+ typeToColor(String)*1)% 360)
   })
+
+  onWorkspace('distintos colores para funciones con los mismos tipos de parametros pero en distinto orden', workspace => {
+    const fABType = createType(["Number", "Boolean"])
+    const fBAType = createType(["Boolean", "Number"])
+
+    assert.notEqual(typeToColor(fABType), typeToColor(fBAType))
+  })
+
+
 })


### PR DESCRIPTION
Hola Nahuel,

Este PR tiene el primer boceto de la formula que calcula el color del tipo estructural contemplando el orden de los parámetros. 
Lo que hice por el momento es modificar la idea original que te comenté acerca de elevar a la potencia de acuerdo a su posición en el array por una multiplicación simple por el número de la posición. Esta  simplificación me ayudo a reparar los test. Voy a seguir explorando variantes para esa formula porque no estoy del todo seguro si garantiza resultados que no repitan los colores.
Mientras hago este PR para que vayas viendo como encare la solución. 
