### PR TITLE
Fixes 46 orden superior y listas invalidas

### DIFF
--- a/src/typeSystem.js
+++ b/src/typeSystem.js
@@ -266,7 +266,11 @@ function constraints(block) {
 }
 
 function blockConstraints(functionBlock) {
-  return solveConstraints({ constraints: constraints(functionBlock), typeDictionary: {} })
+  try {
+    return solveConstraints({ constraints: constraints(functionBlock), typeDictionary: {} })
+  } catch(error) {
+    return { error: error.message }
+  }
 }
 
 function typeVariables(functionBlock) {

--- a/test/connectionListSpec.js
+++ b/test/connectionListSpec.js
@@ -30,7 +30,7 @@ describe('List connections', () => {
     assertConnection(list, text2)
   })
 
-  onWorkspace('should reject other tipe elements', workspace => {
+  onWorkspace('should reject other type elements', workspace => {
     const list = workspace.newBlock('list')
     const text = workspace.newBlock('text')
     const number = workspace.newBlock('math_number')
@@ -38,6 +38,21 @@ describe('List connections', () => {
     connect(list, text, 0)
     connect(list, number, 1)
 
+    assertConnection(list, text)
+    assertRejectedConnection(list, number)
+  })
+
+  onWorkspace('should reject other type elements even when the list is a parameter on another block', workspace => {
+    const any = workspace.newBlock('any')
+    const list = workspace.newBlock('list')
+    const text = workspace.newBlock('text')
+    const number = workspace.newBlock('math_number')
+
+    connect(any, list, 1)
+    connect(list, text, 0)
+    connect(list, number, 1)
+
+    assertConnection(any, list)
     assertConnection(list, text)
     assertRejectedConnection(list, number)
   })


### PR DESCRIPTION
Fix https://github.com/uqbar-project/function-laboratory/issues/46

El problema era que en `blockConstraints`, se esperaba que devuelva un objeto que contenga el error o no (en vez de que lance una excepción). Pero evaluar `constraints(functionBlock)` podía levantar una excepción y esa no se estaba atrapando en ningún lado.

También, agrego otro issue para revisar como estamos manejando los casos de error y excepciones en el type system que creo que es mejorable 😅 : https://github.com/uqbar-project/function-laboratory/issues/49