### PR TITLE
Fixes 45 Avoid checking connections while blocks are being drag

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1,5 +1,5 @@
 function onChangeBlock(event) {
-  if (event.blockId == this.id) {
+  if (event.blockId == this.id && !this.workspace.isDragging()) {
     checkParentConnection(this)
   }
   if (!blockConstraints(this).error) {


### PR DESCRIPTION
It seems that while blocks are being dragged, the inputList doesn't yield the same results as when they are still. And since our type checking depends in the inputList it raises a type error that shouldn't happen when detaching a block from another


https://user-images.githubusercontent.com/11432672/113456673-3e2e9980-93e4-11eb-8809-6acea32515de.mp4

I tried to test this but had problems trying to reproduce what happens on the test so I made the PR anyways because it seemed a pretty important bug to fix for the demo, but if you want we can try to investigate how we could test this @PalumboN 
